### PR TITLE
docs(README.md): fix text "文件处"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Ensure that you've read through the extensions guidelines and follow the best pr
 
 ## Working with Markdown
 
-* 在文件夹出鼠标右击即可看到“快速生成一个react antd页面”
+* 在文件夹处鼠标右击即可看到“快速生成一个react antd页面”
 
 ### For more information
 

--- a/src/template/simplePage/index.ts
+++ b/src/template/simplePage/index.ts
@@ -16,7 +16,7 @@ const App: React.FC<AppProps> = (props) => {
 
   useEffect(() => {
     // useEffect在组件初始化或依赖更新时执行
-    // 依赖可以有多个，但主要注意的是，当依赖中有state时，不要在useEffct中再写该状态的set操作，会造成死循环111
+    // 依赖可以有多个，但主要注意的是，当依赖中有state时，不要在useEffect中再写该状态的set操作，会造成死循环
 
   }, [propsOne, propsTwo, state])
   return (


### PR DESCRIPTION
- 修复 README.md 「在文件夹处鼠标右击即可看到“快速生成一个react antd页面」
- 修复 simplePage/index.ts 「依赖可以有多个，但主要注意的是，当依赖中有state时，不要在useEffect中再写该状态的set操作，会造成死循环」